### PR TITLE
start server.js and print port when started

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "start": "node serve"
+    "start": "node server.js"
   },
   "private": true,
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -1,9 +1,10 @@
 // server.js
 const express = require('express');
 const app = express();
+const PORT = process.env.PORT || 8080;
 // Run the app by serving the static files
 // in the dist directory
 app.use(express.static(__dirname + '/dist'));
 // Start the app by listening on the default
 // Heroku port
-app.listen(process.env.PORT || 8080);
+app.listen(PORT, () => console.log(`Running on port ${PORT}`));


### PR DESCRIPTION
- fix bug: run express from server.js
- print port when the server has started